### PR TITLE
fix: use package-directory for content file resolution

### DIFF
--- a/src/platform/refreshPlatformContent.ts
+++ b/src/platform/refreshPlatformContent.ts
@@ -9,10 +9,11 @@
  */
 
 import { cpSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import Handlebars from 'handlebars';
+import { packageDirectorySync } from 'package-directory';
 
 import {
   AGENTS_MARKERS,
@@ -66,13 +67,24 @@ interface VersionInfoEntry {
 /**
  * Resolve the package's content directory.
  *
+ * @remarks
+ * Uses `package-directory` to locate the package root regardless of
+ * whether this code runs from `src/platform/` (dev) or `dist/` (bundled).
+ * Rollup flattens all source into `dist/index.js`, so static relative
+ * paths like `../../content/` break when consumed as a dependency.
+ *
  * @returns Absolute path to the content/ directory.
  */
 function getContentDir(): string {
-  const thisFile = fileURLToPath(import.meta.url);
-  // From src/platform/refreshPlatformContent.ts → ../../content/
-  // From dist/platform/refreshPlatformContent.js → ../../content/
-  return join(dirname(thisFile), '..', '..', 'content');
+  const pkgDir = packageDirectorySync({
+    cwd: fileURLToPath(import.meta.url),
+  });
+  if (!pkgDir) {
+    throw new Error(
+      'Could not find package root from ' + fileURLToPath(import.meta.url),
+    );
+  }
+  return join(pkgDir, 'content');
 }
 
 /**


### PR DESCRIPTION
## Problem (two related bugs)

**Bug 1:** \efreshPlatformContent()\ resolved content files using static relative paths (\../../content/\). Rollup flattens to \dist/index.js\, so the path was wrong.

**Bug 2 (deeper):** Even with \packageDirectorySync\, when plugins *bundle* core into their own \dist/index.js\, \import.meta.url\ points to the consumer's bundle. \packageDirectorySync\ finds the consumer's \package.json\, which has no \content/\ directory.

**Result:** All four component plugins logged \content file missing\ errors. Managed blocks in SOUL.md and AGENTS.md were written with markers but empty content.

## Fix

**Commit 1 (\85f2f38\):** Use \packageDirectorySync\ for path resolution (fixes unbundled case).

**Commit 2 (\5e4fb45\):** Inline content files at build time via a rollup md plugin. Content \.md\ files are imported as ES module string literals, eliminating runtime filesystem dependencies entirely. Templates (which need to be copied as actual files) fall back gracefully when the content directory isn't available (template seeding is a CLI concern, not a plugin concern).

## Tests

110 tests passing. All STAN gates green (lint, test, typecheck, knip, build, docs).