### PR TITLE
fix: inline content files at build time (fixes empty managed sections when bundled)

### DIFF
--- a/rollup-plugin-md.ts
+++ b/rollup-plugin-md.ts
@@ -1,0 +1,29 @@
+import type { Plugin } from 'rollup';
+
+/**
+ * Rollup plugin that imports `.md` files as ES modules exporting
+ * the file content as a default string.
+ *
+ * @remarks
+ * This eliminates runtime filesystem dependencies for content files
+ * that are bundled into consumer plugins. When a plugin bundles
+ * `@karmaniverous/jeeves`, `import.meta.url` points to the consumer's
+ * bundle, so `packageDirectorySync` finds the wrong `package.json`.
+ * Inlining the content at build time sidesteps the issue entirely.
+ */
+export function mdPlugin(): Plugin {
+  return {
+    name: 'md-string',
+    transform(code: string, id: string) {
+      if (!id.endsWith('.md')) return null;
+      const escaped = code
+        .replace(/\\/g, '\\\\')
+        .replace(/`/g, '\\`')
+        .replace(/\$/g, '\\$');
+      return {
+        code: `export default \`${escaped}\`;\n`,
+        map: { mappings: '' },
+      };
+    },
+  };
+}

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -9,6 +9,8 @@ import fs from 'fs-extra';
 import type { InputOptions, RollupOptions } from 'rollup';
 import dtsPlugin from 'rollup-plugin-dts';
 
+import { mdPlugin } from './rollup-plugin-md.js';
+
 const require = createRequire(import.meta.url);
 type Package = Record<string, Record<string, string> | undefined>;
 const pkg = require('./package.json') as Package;
@@ -38,6 +40,7 @@ const typescript = typescriptPlugin({
 const commonPlugins = [
   commonjsPlugin(),
   jsonPlugin(),
+  mdPlugin(),
   nodeResolve(),
   typescript,
 ];

--- a/src/md.d.ts
+++ b/src/md.d.ts
@@ -1,0 +1,4 @@
+declare module '*.md' {
+  const content: string;
+  export default content;
+}

--- a/src/platform/refreshPlatformContent.ts
+++ b/src/platform/refreshPlatformContent.ts
@@ -8,13 +8,16 @@
  * and writes managed sections using `updateManagedSection`.
  */
 
-import { cpSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import Handlebars from 'handlebars';
 import { packageDirectorySync } from 'package-directory';
 
+import agentsSectionContent from '../../content/agents-section.md';
+import soulSectionContent from '../../content/soul-section.md';
+import toolsPlatformTemplate from '../../content/tools-platform.md';
 import {
   AGENTS_MARKERS,
   SOUL_MARKERS,
@@ -65,41 +68,27 @@ interface VersionInfoEntry {
 }
 
 /**
- * Resolve the package's content directory.
+ * Resolve the package's content directory for template file copying.
  *
  * @remarks
- * Uses `package-directory` to locate the package root regardless of
- * whether this code runs from `src/platform/` (dev) or `dist/` (bundled).
- * Rollup flattens all source into `dist/index.js`, so static relative
- * paths like `../../content/` break when consumed as a dependency.
+ * Templates are actual files that need to be copied to the config directory.
+ * This only works when core is in `node_modules` (CLI install, service).
+ * When bundled into a consumer plugin, returns undefined and template
+ * copying is skipped (templates are seeded by `jeeves install`, not plugins).
  *
- * @returns Absolute path to the content/ directory.
+ * Content `.md` files (soul, agents, platform template) are inlined at
+ * build time via the rollup md plugin and imported as string literals.
+ * They do not use this function.
+ *
+ * @returns Absolute path to the content/ directory, or undefined.
  */
-function getContentDir(): string {
+function getContentDir(): string | undefined {
   const pkgDir = packageDirectorySync({
     cwd: fileURLToPath(import.meta.url),
   });
-  if (!pkgDir) {
-    throw new Error(
-      'Could not find package root from ' + fileURLToPath(import.meta.url),
-    );
-  }
-  return join(pkgDir, 'content');
-}
-
-/**
- * Read a content file from the package's content/ directory.
- *
- * @param fileName - File name within content/.
- * @returns File content as string, or empty string if missing.
- */
-function readContentFile(fileName: string): string {
-  const filePath = join(getContentDir(), fileName);
-  if (!existsSync(filePath)) {
-    console.warn(`jeeves-core: content file missing: ${filePath}`);
-    return '';
-  }
-  return readFileSync(filePath, 'utf-8');
+  if (!pkgDir) return undefined;
+  const dir = join(pkgDir, 'content');
+  return existsSync(dir) ? dir : undefined;
 }
 
 /**
@@ -108,7 +97,9 @@ function readContentFile(fileName: string): string {
  * @param coreConfigDir - Core config directory path.
  */
 function copyTemplates(coreConfigDir: string): void {
-  const sourceDir = join(getContentDir(), 'templates');
+  const contentDir = getContentDir();
+  if (!contentDir) return;
+  const sourceDir = join(contentDir, 'templates');
   if (!existsSync(sourceDir)) return;
 
   const destDir = join(coreConfigDir, TEMPLATES_DIR);
@@ -184,8 +175,7 @@ export async function refreshPlatformContent(
 
   // 4. Render Platform template
   registerHelpers();
-  const templateSrc = readContentFile('tools-platform.md');
-  const template = Handlebars.compile(templateSrc);
+  const template = Handlebars.compile(toolsPlatformTemplate);
   const templateData: PlatformTemplateData = {
     services: probeResults,
     unhealthyServices,
@@ -208,9 +198,8 @@ export async function refreshPlatformContent(
   });
 
   // 6. Write SOUL.md managed block
-  const soulContent = readContentFile('soul-section.md');
   const soulPath = join(workspacePath, WORKSPACE_FILES.soul);
-  await updateManagedSection(soulPath, soulContent, {
+  await updateManagedSection(soulPath, soulSectionContent, {
     mode: 'block',
     markers: SOUL_MARKERS,
     coreVersion,
@@ -218,9 +207,8 @@ export async function refreshPlatformContent(
   });
 
   // 7. Write AGENTS.md managed block
-  const agentsContent = readContentFile('agents-section.md');
   const agentsPath = join(workspacePath, WORKSPACE_FILES.agents);
-  await updateManagedSection(agentsPath, agentsContent, {
+  await updateManagedSection(agentsPath, agentsSectionContent, {
     mode: 'block',
     markers: AGENTS_MARKERS,
     coreVersion,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,28 @@
-import { defineConfig } from 'vitest/config';
+import { readFileSync } from 'node:fs';
+
+import { defineConfig, type Plugin } from 'vitest/config';
+
+/** Vitest plugin to import .md files as default string exports. */
+function mdPlugin(): Plugin {
+  return {
+    name: 'md-string',
+    transform(_code: string, id: string) {
+      if (!id.endsWith('.md')) return null;
+      const content = readFileSync(id, 'utf-8');
+      const escaped = content
+        .replace(/\\/g, '\\\\')
+        .replace(/`/g, '\\`')
+        .replace(/\$/g, '\\$');
+      return {
+        code: `export default \`${escaped}\`;\n`,
+        map: null,
+      };
+    },
+  };
+}
 
 export default defineConfig({
+  plugins: [mdPlugin()],
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
v0.1.2 fixed path resolution for the unbundled case, but when plugins bundle core via rollup, \import.meta.url\ points to the consumer's bundle and \packageDirectorySync\ finds the wrong \package.json\.

**Fix:** Rollup md plugin inlines \.md\ content as string literals at build time. No runtime filesystem resolution for content files. Template copying (CLI concern) is best-effort via \packageDirectorySync\, gracefully skipped when bundled.

110 tests, all STAN gates green.