### PR TITLE
fix: add resolveWorkspacePath to core

### DIFF
--- a/src/component/index.ts
+++ b/src/component/index.ts
@@ -13,6 +13,10 @@ export {
   createComponentWriter,
   type CreateComponentWriterOptions,
 } from './createComponentWriter.js';
+export {
+  type PluginApiLike,
+  resolveWorkspacePath,
+} from './resolveWorkspacePath.js';
 export type {
   JeevesComponent,
   PluginCommands,

--- a/src/component/resolveWorkspacePath.test.ts
+++ b/src/component/resolveWorkspacePath.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PluginApiLike } from './resolveWorkspacePath.js';
+import { resolveWorkspacePath } from './resolveWorkspacePath.js';
+
+describe('resolveWorkspacePath', () => {
+  it('uses api.resolvePath when available', () => {
+    const api: PluginApiLike = {
+      resolvePath: () => '/from/resolve-path',
+      config: { agents: { defaults: { workspace: '/from/config' } } },
+    };
+    expect(resolveWorkspacePath(api)).toBe('/from/resolve-path');
+  });
+
+  it('falls back to config workspace when resolvePath is absent', () => {
+    const api: PluginApiLike = {
+      config: { agents: { defaults: { workspace: '/from/config' } } },
+    };
+    expect(resolveWorkspacePath(api)).toBe('/from/config');
+  });
+
+  it('falls back to config workspace when resolvePath is not a function', () => {
+    const api = {
+      resolvePath: 'not-a-function',
+      config: { agents: { defaults: { workspace: '/from/config' } } },
+    } as unknown as PluginApiLike;
+    expect(resolveWorkspacePath(api)).toBe('/from/config');
+  });
+
+  it('ignores empty or whitespace-only config workspace', () => {
+    const api: PluginApiLike = {
+      config: { agents: { defaults: { workspace: '   ' } } },
+    };
+    expect(resolveWorkspacePath(api)).toBe(process.cwd());
+  });
+
+  it('falls back to process.cwd when nothing is configured', () => {
+    const api: PluginApiLike = {};
+    expect(resolveWorkspacePath(api)).toBe(process.cwd());
+  });
+
+  it('falls back to process.cwd when config is undefined', () => {
+    const api: PluginApiLike = { config: undefined };
+    expect(resolveWorkspacePath(api)).toBe(process.cwd());
+  });
+
+  it('falls back to process.cwd when agents is undefined', () => {
+    const api: PluginApiLike = { config: {} };
+    expect(resolveWorkspacePath(api)).toBe(process.cwd());
+  });
+});

--- a/src/component/resolveWorkspacePath.ts
+++ b/src/component/resolveWorkspacePath.ts
@@ -1,0 +1,57 @@
+/**
+ * Resolve the OpenClaw workspace root from the plugin API.
+ *
+ * @remarks
+ * Tries three sources in order:
+ * 1. `api.resolvePath('.')` — the gateway-provided resolver (most authoritative)
+ * 2. `api.config.agents.defaults.workspace` — the OpenClaw config value
+ * 3. `process.cwd()` — last resort (unsafe when gateway runs from system32)
+ *
+ * Plugins should call this once at registration time and pass the result
+ * to `init({ workspacePath })`.
+ */
+
+/**
+ * Minimal shape of the OpenClaw plugin API needed for workspace resolution.
+ *
+ * @remarks
+ * Intentionally loose — plugins define their own full `PluginApi` type.
+ * This captures only the fields `resolveWorkspacePath` inspects.
+ */
+export interface PluginApiLike {
+  /** Gateway-provided path resolver. May not exist in all gateway versions. */
+  resolvePath?: (input: string) => string;
+  /** OpenClaw configuration object. */
+  config?: {
+    /** Agent configuration block. */
+    agents?: {
+      /** Default agent settings. */
+      defaults?: {
+        /** Absolute path to the workspace root directory. */
+        workspace?: string;
+      };
+    };
+  };
+}
+
+/**
+ * Resolve the workspace root from the OpenClaw plugin API.
+ *
+ * @param api - The plugin API object provided by the gateway at registration.
+ * @returns Absolute path to the workspace root.
+ */
+export function resolveWorkspacePath(api: PluginApiLike): string {
+  // 1. Gateway-provided resolver (most authoritative)
+  if (typeof api.resolvePath === 'function') {
+    return api.resolvePath('.');
+  }
+
+  // 2. OpenClaw config value
+  const configured = api.config?.agents?.defaults?.workspace;
+  if (typeof configured === 'string' && configured.trim()) {
+    return configured;
+  }
+
+  // 3. Last resort — unsafe when gateway runs from system32
+  return process.cwd();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,9 @@ export {
   createComponentWriter,
   type CreateComponentWriterOptions,
   type JeevesComponent,
+  type PluginApiLike,
   type PluginCommands,
+  resolveWorkspacePath,
   type ServiceCommands,
   type ServiceStatus,
 } from './component/index.js';


### PR DESCRIPTION
## Problem\n\nWhen the OpenClaw gateway runs as a Windows service, its working directory is `C:\Windows\system32`. Plugins that fall back to `process.cwd()` for workspace resolution write SOUL.md, AGENTS.md, and TOOLS.md to system32 instead of the actual workspace.\n\n## Root Cause\n\nEach plugin independently implemented `resolveWorkspacePath()` with a three-step fallback chain:\n1. `api.resolvePath(".")` — gateway-provided\n2. `api.config.agents.defaults.workspace` — OpenClaw config\n3. `process.cwd()` — unsafe fallback\n\nPlugins deployed before the config fallback was discovered used only steps 1 and 3, hitting the unsafe fallback.\n\n## Fix\n\nExport `resolveWorkspacePath(api)` from core so every plugin gets the correct three-step chain for free. Plugins should use this instead of reimplementing the logic.\n\n## Changes\n\n- New: `resolveWorkspacePath(api: PluginApiLike): string` exported from core\n- New: `PluginApiLike` interface (minimal API shape for workspace resolution)\n- 7 unit tests covering all fallback paths\n- Zero lint/typecheck/knip/docs warnings