### PR TITLE
fix: CORE_VERSION inlining, H1 titles, merge Service Health table

### DIFF
--- a/content/tools-platform.md
+++ b/content/tools-platform.md
@@ -1,17 +1,7 @@
-{{#if versionInfo}}
-| Component | Service | Plugin | Core | Available |
-|-----------|---------|--------|------|-----------|
-{{#each versionInfo}}
-| **{{name}}** | {{#if serviceVersion}}{{serviceVersion}}{{else}}—{{/if}} | {{#if pluginVersion}}{{pluginVersion}}{{else}}—{{/if}} | {{coreVersion}} | {{#if availableVersion}}⬆ {{availableVersion}}{{else}}✓ current{{/if}} |
-{{/each}}
-{{/if}}
-
-### Service Health
-
-| Service | Port | Status |
-|---------|------|--------|
+| Component | Port | Status | Service | Plugin | Core |
+|-----------|------|--------|---------|--------|------|
 {{#each services}}
-| {{name}} | {{port}} | {{#if healthy}}✅ Running{{#if version}} (v{{version}}){{/if}}{{else}}{{#if error}}⚠️ {{error}}{{else}}❌ Down{{/if}}{{/if}} |
+| **{{name}}** | {{port}} | {{#if healthy}}✅ Running{{else}}{{#if error}}⚠️ {{error}}{{else}}❌ Down{{/if}}{{/if}} | {{#if version}}{{version}}{{#if availableServiceVersion}} (⬆ {{availableServiceVersion}}){{/if}}{{else}}—{{/if}} | {{#if pluginVersion}}{{pluginVersion}}{{#if availablePluginVersion}} (⬆ {{availablePluginVersion}}){{/if}}{{else}}—{{/if}} | {{../coreVersion}}{{#if ../availableCoreVersion}} (⬆ {{../availableCoreVersion}}){{/if}} |
 {{/each}}
 
 {{#if unhealthyServices}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@rollup/plugin-commonjs": "^29.0.0",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
+        "@rollup/plugin-replace": "^6.0.3",
         "@rollup/plugin-typescript": "^12.3.0",
         "@types/fs-extra": "^11.0.4",
         "@types/node": "^25.0.3",
@@ -1925,6 +1926,28 @@
       },
       "peerDependencies": {
         "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
+    "@rollup/plugin-replace": "^6.0.3",
     "@rollup/plugin-typescript": "^12.3.0",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^25.0.3",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -4,6 +4,7 @@ import aliasPlugin, { type Alias } from '@rollup/plugin-alias';
 import commonjsPlugin from '@rollup/plugin-commonjs';
 import jsonPlugin from '@rollup/plugin-json';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import replacePlugin from '@rollup/plugin-replace';
 import typescriptPlugin from '@rollup/plugin-typescript';
 import fs from 'fs-extra';
 import type { InputOptions, RollupOptions } from 'rollup';
@@ -38,6 +39,10 @@ const typescript = typescriptPlugin({
 });
 
 const commonPlugins = [
+  replacePlugin({
+    __JEEVES_CORE_VERSION__: (pkg as unknown as { version: string }).version,
+    preventAssignment: true,
+  }),
   commonjsPlugin(),
   jsonPlugin(),
   mdPlugin(),

--- a/src/component/ComponentWriter.ts
+++ b/src/component/ComponentWriter.ts
@@ -98,6 +98,9 @@ export class ComponentWriter {
       await refreshPlatformContent({
         coreVersion: CORE_VERSION,
         componentName: this.component.name,
+        componentVersion: this.component.version,
+        servicePackage: this.component.servicePackage,
+        pluginPackage: this.component.pluginPackage,
         skipRegistryCheck: false,
         probeTimeoutMs: this.probeTimeoutMs,
       });

--- a/src/component/types.ts
+++ b/src/component/types.ts
@@ -40,8 +40,12 @@ export interface PluginCommands {
 export interface JeevesComponent {
   /** Component name (e.g., 'watcher', 'runner', 'server', 'meta'). */
   name: string;
-  /** Component's own version. */
+  /** Component's own version (plugin package version). */
   version: string;
+  /** npm package name for the service (e.g., `\@karmaniverous/jeeves-watcher`). */
+  servicePackage?: string;
+  /** npm package name for the plugin (e.g., `\@karmaniverous/jeeves-watcher-openclaw`). */
+  pluginPackage?: string;
   /** TOOLS.md section name (e.g., 'Watcher'). */
   sectionId: string;
   /** Refresh interval in seconds (must be a prime number). */

--- a/src/constants/markers.ts
+++ b/src/constants/markers.ts
@@ -24,6 +24,8 @@ export const SOUL_MARKERS = {
   begin: 'BEGIN JEEVES SOUL — DO NOT EDIT THIS SECTION',
   /** END comment marker text. */
   end: 'END JEEVES SOUL',
+  /** H1 title prepended in the managed block. */
+  title: 'Jeeves Platform Soul',
 } as const;
 
 /** Default markers for AGENTS.md managed block. */
@@ -32,6 +34,8 @@ export const AGENTS_MARKERS = {
   begin: 'BEGIN JEEVES AGENTS — DO NOT EDIT THIS SECTION',
   /** END comment marker text. */
   end: 'END JEEVES AGENTS',
+  /** H1 title prepended in the managed block. */
+  title: 'Jeeves Platform Agents',
 } as const;
 
 /**

--- a/src/constants/version.ts
+++ b/src/constants/version.ts
@@ -1,30 +1,13 @@
 /**
- * Core library version, read from package.json at runtime.
+ * Core library version, inlined at build time.
  *
  * @remarks
- * Used for version-stamp convergence (Decision 21). The version stamp
- * on managed content reflects the actual published library version,
- * enabling higher-version writers to take precedence.
- *
- * Uses `package-directory` to locate the package root regardless of
- * whether this code runs from `src/constants/` (dev) or `dist/` (bundled).
+ * The `__JEEVES_CORE_VERSION__` placeholder is replaced by
+ * `@rollup/plugin-replace` during the build with the actual version
+ * from `package.json`. This ensures the correct version survives
+ * when consumers bundle core into their own dist (where runtime
+ * `import.meta.url`-based resolution would find the wrong package.json).
  */
 
-import { createRequire } from 'node:module';
-import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-import { packageDirectorySync } from 'package-directory';
-
-const pkgDir = packageDirectorySync({ cwd: fileURLToPath(import.meta.url) });
-if (!pkgDir) {
-  throw new Error(
-    'Could not find package root from ' + fileURLToPath(import.meta.url),
-  );
-}
-
-const require = createRequire(import.meta.url);
-const pkg = require(join(pkgDir, 'package.json')) as { version: string };
-
-/** The core library version from package.json. */
-export const CORE_VERSION: string = pkg.version;
+/** The core library version from package.json (inlined at build time). */
+export const CORE_VERSION: string = '__JEEVES_CORE_VERSION__';

--- a/src/managed/updateManagedSection.ts
+++ b/src/managed/updateManagedSection.ts
@@ -114,7 +114,10 @@ export async function updateManagedSection(
     let newManagedBody: string;
 
     if (mode === 'block') {
-      newManagedBody = content;
+      // Prepend H1 title if markers specify one
+      newManagedBody = markers.title
+        ? `# ${markers.title}\n\n${content}`
+        : content;
     } else {
       // Section mode: upsert the named section
       const sections = [...parsed.sections];

--- a/src/platform/refreshPlatformContent.test.ts
+++ b/src/platform/refreshPlatformContent.test.ts
@@ -87,7 +87,7 @@ describe('refreshPlatformContent', () => {
     expect(parsed.sections.some((s) => s.id === 'Platform')).toBe(true);
 
     const platform = parsed.sections.find((s) => s.id === 'Platform');
-    expect(platform?.content).toContain('Service Health');
+    expect(platform?.content).toContain('Status');
   }, 15_000);
 
   it('should include version stamp in markers', async () => {

--- a/src/platform/refreshPlatformContent.ts
+++ b/src/platform/refreshPlatformContent.ts
@@ -40,6 +40,12 @@ export interface RefreshPlatformContentOptions {
   coreVersion: string;
   /** Component name (for registry cache directory). */
   componentName?: string;
+  /** Component plugin version (e.g., '0.2.0'). */
+  componentVersion?: string;
+  /** npm package name for the service (for registry update check). */
+  servicePackage?: string;
+  /** npm package name for the plugin (for registry update check). */
+  pluginPackage?: string;
   /** Staleness threshold override in ms. */
   stalenessThresholdMs?: number;
   /** Timeout for health probes in ms. */
@@ -48,23 +54,24 @@ export interface RefreshPlatformContentOptions {
   skipRegistryCheck?: boolean;
 }
 
-/** Data passed to the Handlebars Platform template. */
-interface PlatformTemplateData {
-  services: ProbeResult[];
-  unhealthyServices: ProbeResult[];
-  versionInfo?: VersionInfoEntry[];
-  pointCount?: number;
-  templatesAvailable: boolean;
-  templatePath: string;
+/** Per-service row data for the Platform template. */
+interface ServiceRow extends ProbeResult {
+  /** Plugin version for this component. */
+  pluginVersion?: string;
+  /** Available service update from npm registry. */
+  availableServiceVersion?: string;
+  /** Available plugin update from npm registry. */
+  availablePluginVersion?: string;
 }
 
-/** Version information for a component. */
-interface VersionInfoEntry {
-  name: string;
-  serviceVersion?: string;
-  pluginVersion?: string;
+/** Data passed to the Handlebars Platform template. */
+interface PlatformTemplateData {
+  services: ServiceRow[];
+  unhealthyServices: ProbeResult[];
   coreVersion: string;
-  availableVersion?: string;
+  availableCoreVersion?: string;
+  templatesAvailable: boolean;
+  templatePath: string;
 }
 
 /**
@@ -138,6 +145,9 @@ export async function refreshPlatformContent(
   const {
     coreVersion,
     componentName,
+    componentVersion,
+    servicePackage,
+    pluginPackage,
     stalenessThresholdMs,
     probeTimeoutMs = 3000,
     skipRegistryCheck = false,
@@ -150,44 +160,67 @@ export async function refreshPlatformContent(
   const probeResults = await probeAllServices(undefined, probeTimeoutMs);
   const unhealthyServices = probeResults.filter((r) => !r.healthy);
 
-  // 2. Build version info (registry check for the core package)
-  let availableVersion: string | undefined;
+  // 2. Registry version checks
+  const cacheDir = componentName
+    ? getComponentConfigDir(componentName)
+    : coreConfigDir;
+
+  let availableCoreVersion: string | undefined;
+  let availableServiceVersion: string | undefined;
+  let availablePluginVersion: string | undefined;
+
   if (!skipRegistryCheck) {
-    const cacheDir = componentName
-      ? getComponentConfigDir(componentName)
-      : coreConfigDir;
-    availableVersion = checkRegistryVersion('@karmaniverous/jeeves', cacheDir);
+    const coreRegistryVersion = checkRegistryVersion(
+      '@karmaniverous/jeeves',
+      cacheDir,
+    );
+    if (coreRegistryVersion && coreRegistryVersion !== coreVersion) {
+      availableCoreVersion = coreRegistryVersion;
+    }
+
+    if (servicePackage) {
+      const svcVersion = checkRegistryVersion(servicePackage, cacheDir);
+      if (svcVersion) {
+        availableServiceVersion = svcVersion;
+      }
+    }
+
+    if (pluginPackage) {
+      const plgVersion = checkRegistryVersion(pluginPackage, cacheDir);
+      if (plgVersion) {
+        availablePluginVersion = plgVersion;
+      }
+    }
   }
 
-  const versionInfo: VersionInfoEntry[] = probeResults.map((r) => ({
-    name: r.name,
-    serviceVersion: r.version,
-    coreVersion,
-    availableVersion:
-      availableVersion && availableVersion !== coreVersion
-        ? availableVersion
-        : undefined,
+  // 3. Build enriched service rows — match the calling component by name
+  const serviceRows: ServiceRow[] = probeResults.map((r) => ({
+    ...r,
+    pluginVersion: r.name === componentName ? componentVersion : undefined,
+    availableServiceVersion:
+      r.name === componentName ? availableServiceVersion : undefined,
+    availablePluginVersion:
+      r.name === componentName ? availablePluginVersion : undefined,
   }));
 
-  // 3. Check if templates are available
+  // 5. Check if templates are available
   const templatePath = join(coreConfigDir, TEMPLATES_DIR);
   const templatesAvailable = existsSync(templatePath);
 
-  // 4. Render Platform template
+  // 6. Render Platform template
   registerHelpers();
   const template = Handlebars.compile(toolsPlatformTemplate);
   const templateData: PlatformTemplateData = {
-    services: probeResults,
+    services: serviceRows,
     unhealthyServices,
-    versionInfo: versionInfo.some((v) => v.serviceVersion)
-      ? versionInfo
-      : undefined,
+    coreVersion,
+    availableCoreVersion,
     templatesAvailable,
     templatePath,
   };
   const platformContent = template(templateData);
 
-  // 5. Write TOOLS.md Platform section
+  // 7. Write TOOLS.md Platform section
   const toolsPath = join(workspacePath, WORKSPACE_FILES.tools);
   await updateManagedSection(toolsPath, platformContent, {
     mode: 'section',
@@ -197,7 +230,7 @@ export async function refreshPlatformContent(
     stalenessThresholdMs,
   });
 
-  // 6. Write SOUL.md managed block
+  // 8. Write SOUL.md managed block
   const soulPath = join(workspacePath, WORKSPACE_FILES.soul);
   await updateManagedSection(soulPath, soulSectionContent, {
     mode: 'block',
@@ -206,7 +239,7 @@ export async function refreshPlatformContent(
     stalenessThresholdMs,
   });
 
-  // 7. Write AGENTS.md managed block
+  // 9. Write AGENTS.md managed block
   const agentsPath = join(workspacePath, WORKSPACE_FILES.agents);
   await updateManagedSection(agentsPath, agentsSectionContent, {
     mode: 'block',
@@ -215,6 +248,6 @@ export async function refreshPlatformContent(
     stalenessThresholdMs,
   });
 
-  // 8. Copy templates to config dir
+  // 10. Copy templates to config dir
   copyTemplates(coreConfigDir);
 }


### PR DESCRIPTION
## Changes\n\n### 1. CORE_VERSION build-time inlining\n`version.ts` no longer resolves the version at runtime via `packageDirectorySync`. Instead, `@rollup/plugin-replace` substitutes `__JEEVES_CORE_VERSION__` with the actual version from `package.json` during the build. This fixes the bug where plugins bundling core would resolve the plugin's version instead of core's.\n\n### 2. H1 titles for SOUL.md and AGENTS.md\nAdded `title` field to `SOUL_MARKERS` and `AGENTS_MARKERS`. Updated `updateManagedSection` to prepend the H1 title in block mode (previously only section mode). SOUL.md now gets `# Jeeves Platform Soul` and AGENTS.md gets `# Jeeves Platform Agents`.\n\n### 3. Service Health merged into Platform table\nThe standalone Service Health section is removed. Status, port, and version data are now columns in the unified Platform table. Eliminates redundancy.\n\n## Testing\n- 118 tests passing\n- Zero lint/typecheck/knip/docs warnings\n- Verified `CORE_VERSION = '0.1.4'` in built output