### PR TITLE
fix: resolve commander ESM import failure in published CLI build

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -43,7 +43,7 @@ const commonPlugins = [
     __JEEVES_CORE_VERSION__: (pkg as unknown as { version: string }).version,
     preventAssignment: true,
   }),
-  commonjsPlugin({ esmExternals: true }),
+  commonjsPlugin({ esmExternals: ['commander'] }),
   jsonPlugin(),
   mdPlugin(),
   nodeResolve(),


### PR DESCRIPTION
Problem: Published CLI (npx @karmaniverous/jeeves) fails on Node 22 and 24 with SyntaxError: The requested module 'commander' does not provide an export named 'default'.

Cause: Rollup's commonjs plugin synthesizes a default import for commander, but commander v14's ESM entry only exports named exports.

Fix: One-line change — commonjsPlugin({ esmExternals: true }) — produces import * as commander instead of import require$$0 from 'commander'.

Tested: Rebuilt and ran jeeves install, jeeves status successfully on Node 22.22.2 and 24.14.0 against a production OpenClaw v2026.3.13 system.