### PR TITLE
fix: config CLI tree and config apply wire format

### DIFF
--- a/src/cli/service/createServiceCli.test.ts
+++ b/src/cli/service/createServiceCli.test.ts
@@ -51,9 +51,18 @@ describe('createServiceCli', () => {
     expect(configCmd).toBeDefined();
 
     const subCmds = configCmd!.commands.map((c) => c.name());
-    expect(subCmds).toContain('query');
+    expect(subCmds).not.toContain('query');
     expect(subCmds).toContain('validate');
     expect(subCmds).toContain('apply');
+  });
+
+  it('config command should accept jsonpath argument directly', () => {
+    const program = createServiceCli(makeTestDescriptor());
+    const configCmd = program.commands.find((c) => c.name() === 'config');
+    expect(configCmd).toBeDefined();
+    const args = configCmd!.registeredArguments;
+    expect(args.length).toBeGreaterThan(0);
+    expect(args[0].name()).toBe('jsonpath');
   });
 
   it('should have service subcommands', () => {

--- a/src/cli/service/createServiceCli.ts
+++ b/src/cli/service/createServiceCli.ts
@@ -29,7 +29,7 @@ import {
  * Standard commands:
  * - `start -c <path>` - Launch the service process (foreground)
  * - `status [-p port]` - Probe service health
- * - `config [jsonpath] [-p port]` - Query running config
+ * - `config [jsonpath] [-p port]` - Query running config (jsonpath optional)
  * - `config validate -c <path>` - Validate a config file
  * - `config apply [-p port] [--file path] [--replace]` - Apply config patch
  * - `init [-o path]` - Generate default config
@@ -90,11 +90,7 @@ export function createServiceCli(
   // --- config ---
   const configCmd = program
     .command('config')
-    .description('Query or manage service configuration');
-
-  configCmd
-    .command('query')
-    .description('Query running service config via JSONPath')
+    .description('Query or manage service configuration')
     .argument('[jsonpath]', 'JSONPath expression')
     .option('-p, --port <port>', 'Service port', String(descriptor.defaultPort))
     .action(async (jsonpath, opts) => {
@@ -152,9 +148,12 @@ export function createServiceCli(
         }
       }
 
-      const qs = opts.replace ? '?replace=true' : '';
+      const body: Record<string, unknown> = { patch };
+      if (opts.replace) {
+        body.replace = true;
+      }
       try {
-        const result = await postJson(`${url}/config/apply${qs}`, patch);
+        const result = await postJson(`${url}/config/apply`, body);
         console.log(JSON.stringify(result, null, 2));
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/src/plugin/createPluginToolset.ts
+++ b/src/plugin/createPluginToolset.ts
@@ -106,7 +106,9 @@ export function createPluginToolset(
         return fail('Missing required parameter: config');
       }
       try {
-        const result = await postJson(`${baseUrl}/config/apply`, config);
+        const result = await postJson(`${baseUrl}/config/apply`, {
+          patch: config,
+        });
         return ok(result);
       } catch (err: unknown) {
         return connectionFail(err, baseUrl, `jeeves-${name}-openclaw`);


### PR DESCRIPTION
## Summary\n\n**Bug 1:** Remove config query subcommand. The config command now accepts the [jsonpath] argument directly, so users type jeeves-watcher config $.watch instead of jeeves-watcher config query $.watch. The \u000balidate and \u0007pply subcommands remain.\n\n**Bug 2:** Fix config apply wire format. The plugin tool (createPluginToolset.ts) now wraps the config patch as { patch: config } to match what configApplyHandler expects. The CLI's config apply command is also updated to send { patch: ..., replace?: true } instead of passing the raw patch with a query string.\n\n## Quality Gates\n- ✅ lint\n- ✅ typecheck\n- ✅ build\n- ✅ test (292 tests passing)