### PR TITLE
fix: resolve config apply path from registered override (#83) + downgrade transient fetch errors (#77)

### DIFF
--- a/src/api/configApplyHandler.test.ts
+++ b/src/api/configApplyHandler.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
-import { init, resetInit } from '../init';
+import { init, registerComponentConfigPath, resetInit } from '../init';
 import { makeTestDescriptor } from '../test/makeTestDescriptor';
 import { createConfigApplyHandler } from './configApplyHandler';
 
@@ -223,5 +223,33 @@ describe('createConfigApplyHandler', () => {
     const body = result.body as Record<string, unknown>;
     expect(body.applied).toBe(true);
     expect(body.warning).toContain('reload failed');
+  });
+
+  it('should use registered config path instead of derived path', async () => {
+    // Create an alternate config directory outside the default configRoot
+    const altDir = join(testDir, 'alt-config');
+    mkdirSync(altDir, { recursive: true });
+    const altConfigPath = join(altDir, 'config.json');
+    writeFileSync(
+      altConfigPath,
+      JSON.stringify({ port: 9999, watchPaths: ['/alt'], debug: true }),
+    );
+
+    // Register the alternate path
+    registerComponentConfigPath('watcher', altConfigPath);
+
+    const handler = createConfigApplyHandler(makeDescriptor());
+    const result = await handler({ patch: { port: 5000 } });
+
+    expect(result.status).toBe(200);
+
+    // Verify it merged with the alt config (port overridden, other fields preserved)
+    const written = JSON.parse(readFileSync(altConfigPath, 'utf-8')) as Record<
+      string,
+      unknown
+    >;
+    expect(written.port).toBe(5000);
+    expect(written.watchPaths).toEqual(['/alt']); // preserved from alt config
+    expect(written.debug).toBe(true); // preserved from alt config
   });
 });

--- a/src/api/configApplyHandler.ts
+++ b/src/api/configApplyHandler.ts
@@ -11,7 +11,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { JeevesComponentDescriptor } from '../component/descriptor.js';
-import { getComponentConfigDir } from '../init.js';
+import { getComponentConfigDir, getComponentConfigPath } from '../init.js';
 import { atomicWrite } from '../managed/fileOps.js';
 import { getErrorMessage } from '../utils.js';
 
@@ -112,9 +112,10 @@ export function createConfigApplyHandler(
   return async (request: ConfigApplyRequest): Promise<ConfigApplyResult> => {
     const { patch, replace } = request;
 
-    // Derive config path
-    const configDir = getComponentConfigDir(descriptor.name);
-    const configPath = join(configDir, descriptor.configFileName);
+    // Use registered config path if available, otherwise derive from configRoot
+    const configPath =
+      getComponentConfigPath(descriptor.name) ??
+      join(getComponentConfigDir(descriptor.name), descriptor.configFileName);
 
     // Read existing config
     const existing = readConfigFile(configPath);

--- a/src/component/createAsyncContentCache.test.ts
+++ b/src/component/createAsyncContentCache.test.ts
@@ -118,4 +118,44 @@ describe('createAsyncContentCache', () => {
     expect(errors).toHaveLength(1);
     expect((errors[0] as Error).message).toBe('boom');
   });
+
+  it('default handler logs transient errors as concise warnings', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const err = new Error('fetch failed');
+    (err as NodeJS.ErrnoException).code = 'ECONNRESET';
+
+    const getContent = createAsyncContentCache({
+      fetch: () => Promise.reject(err),
+    });
+
+    getContent();
+    await vi.advanceTimersToNextTimerAsync();
+    await Promise.resolve();
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const msg = warnSpy.mock.calls[0][0] as string;
+    expect(msg).toContain('transient error');
+    expect(msg).toContain('fetch failed');
+
+    warnSpy.mockRestore();
+  });
+
+  it('default handler logs unexpected errors with full details', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const getContent = createAsyncContentCache({
+      fetch: () => Promise.reject(new Error('unexpected crash')),
+    });
+
+    getContent();
+    await vi.advanceTimersToNextTimerAsync();
+    await Promise.resolve();
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const msg = warnSpy.mock.calls[0][0] as string;
+    expect(msg).toContain('cache refresh failed');
+
+    warnSpy.mockRestore();
+  });
 });

--- a/src/component/createAsyncContentCache.ts
+++ b/src/component/createAsyncContentCache.ts
@@ -29,6 +29,8 @@
  * ```
  */
 
+import { getErrorMessage, isTransientError } from '../utils.js';
+
 /** Options for {@link createAsyncContentCache}. */
 export interface AsyncContentCacheOptions {
   /**
@@ -46,7 +48,8 @@ export interface AsyncContentCacheOptions {
 
   /**
    * Optional error handler. Called when `fetch` throws.
-   * Defaults to `console.warn`.
+   * Defaults to a handler that logs transient network errors as
+   * concise warnings and unexpected errors with full details.
    */
   onError?: (error: unknown) => void;
 }
@@ -64,7 +67,13 @@ export function createAsyncContentCache(
     fetch: fetchContent,
     placeholder = '> Initializing...',
     onError = (err: unknown) => {
-      console.warn('[jeeves] async content cache refresh failed:', err);
+      if (isTransientError(err)) {
+        console.warn(
+          `[jeeves] cache refresh: transient error (${getErrorMessage(err)})`,
+        );
+      } else {
+        console.warn('[jeeves] cache refresh failed:', err);
+      }
     },
   } = options;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,12 +108,14 @@ export {
 } from './discovery/index.js';
 export {
   getComponentConfigDir,
+  getComponentConfigPath,
   getConfigRoot,
   getCoreConfigDir,
   getCoreConfigFile,
   getWorkspacePath,
   init,
   type InitOptions,
+  registerComponentConfigPath,
   resetInit,
 } from './init.js';
 export {
@@ -211,3 +213,4 @@ export {
   type ServiceManager,
   type ServiceManagerOptions,
 } from './service/index.js';
+export { getErrorMessage, isTransientError } from './utils.js';

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -2,11 +2,13 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   getComponentConfigDir,
+  getComponentConfigPath,
   getConfigRoot,
   getCoreConfigDir,
   getCoreConfigFile,
   getWorkspacePath,
   init,
+  registerComponentConfigPath,
   resetInit,
 } from './init';
 
@@ -21,6 +23,12 @@ describe('init', () => {
     expect(() => getCoreConfigDir()).toThrow('init() must be called first');
     expect(() => getCoreConfigFile()).toThrow('init() must be called first');
     expect(() => getComponentConfigDir('watcher')).toThrow(
+      'init() must be called first',
+    );
+    expect(() => {
+      registerComponentConfigPath('watcher', '/path');
+    }).toThrow('init() must be called first');
+    expect(() => getComponentConfigPath('watcher')).toThrow(
       'init() must be called first',
     );
   });
@@ -55,5 +63,26 @@ describe('init', () => {
 
     init({ workspacePath: '/ws2', configRoot: '/cfg2' });
     expect(getWorkspacePath()).toBe('/ws2');
+  });
+
+  it('should register and retrieve component config paths', () => {
+    init({ workspacePath: '/workspace', configRoot: '/config' });
+
+    expect(getComponentConfigPath('watcher')).toBeUndefined();
+
+    registerComponentConfigPath('watcher', '/custom/path/config.json');
+    expect(getComponentConfigPath('watcher')).toBe('/custom/path/config.json');
+
+    // Other components remain unregistered
+    expect(getComponentConfigPath('runner')).toBeUndefined();
+  });
+
+  it('should clear registered paths on re-initialization', () => {
+    init({ workspacePath: '/ws1', configRoot: '/cfg1' });
+    registerComponentConfigPath('watcher', '/custom/path/config.json');
+    expect(getComponentConfigPath('watcher')).toBe('/custom/path/config.json');
+
+    init({ workspacePath: '/ws2', configRoot: '/cfg2' });
+    expect(getComponentConfigPath('watcher')).toBeUndefined();
   });
 });

--- a/src/init.ts
+++ b/src/init.ts
@@ -30,6 +30,8 @@ interface InitState {
   workspacePath: string;
   configRoot: string;
   coreConfigDir: string;
+  /** Per-component config file path overrides (absolute paths). */
+  componentConfigPaths: Map<string, string>;
 }
 
 let state: InitState | undefined;
@@ -44,6 +46,7 @@ export function init(options: InitOptions): void {
     workspacePath: options.workspacePath,
     configRoot: options.configRoot,
     coreConfigDir: join(options.configRoot, CORE_CONFIG_DIR),
+    componentConfigPaths: new Map(),
   };
 }
 
@@ -97,6 +100,41 @@ export function getCoreConfigFile(): string {
 export function getComponentConfigDir(componentName: string): string {
   if (!state) throw new Error('jeeves-core: init() must be called first');
   return join(state.configRoot, `${COMPONENT_CONFIG_PREFIX}${componentName}`);
+}
+
+/**
+ * Register the actual config file path for a component.
+ *
+ * @remarks
+ * Call this after resolving the `--config` CLI argument so that
+ * `getComponentConfigPath` returns the real file location instead of
+ * the default derived from `configRoot`.
+ *
+ * @param componentName - The component name (e.g., 'watcher', 'runner').
+ * @param absolutePath - Absolute path to the component's config file.
+ * @throws Error if `init()` has not been called.
+ */
+export function registerComponentConfigPath(
+  componentName: string,
+  absolutePath: string,
+): void {
+  if (!state) throw new Error('jeeves-core: init() must be called first');
+  state.componentConfigPaths.set(componentName, absolutePath);
+}
+
+/**
+ * Get the registered config file path for a component, or `undefined`
+ * if no override has been registered.
+ *
+ * @param componentName - The component name.
+ * @returns The registered absolute path, or `undefined`.
+ * @throws Error if `init()` has not been called.
+ */
+export function getComponentConfigPath(
+  componentName: string,
+): string | undefined {
+  if (!state) throw new Error('jeeves-core: init() must be called first');
+  return state.componentConfigPaths.get(componentName);
 }
 
 /**

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getErrorMessage } from './utils.js';
+import { getErrorMessage, isTransientError } from './utils.js';
 
 describe('getErrorMessage', () => {
   it('extracts message from Error instances', () => {
@@ -31,5 +31,47 @@ describe('getErrorMessage', () => {
 
   it('stringifies objects', () => {
     expect(getErrorMessage({ code: 'ENOENT' })).toBe('[object Object]');
+  });
+});
+
+describe('isTransientError', () => {
+  it('returns true for ECONNRESET error code', () => {
+    const err = new Error('connection reset');
+    (err as NodeJS.ErrnoException).code = 'ECONNRESET';
+    expect(isTransientError(err)).toBe(true);
+  });
+
+  it('returns true for ETIMEDOUT error code', () => {
+    const err = new Error('timed out');
+    (err as NodeJS.ErrnoException).code = 'ETIMEDOUT';
+    expect(isTransientError(err)).toBe(true);
+  });
+
+  it('returns true for UND_ERR_CONNECT_TIMEOUT error code', () => {
+    const err = new Error('connect timeout');
+    (err as NodeJS.ErrnoException).code = 'UND_ERR_CONNECT_TIMEOUT';
+    expect(isTransientError(err)).toBe(true);
+  });
+
+  it('returns true for AbortError by name', () => {
+    const err = new DOMException('aborted', 'AbortError');
+    expect(isTransientError(err)).toBe(true);
+  });
+
+  it('returns true when cause has transient code', () => {
+    const cause = new Error('inner');
+    (cause as NodeJS.ErrnoException).code = 'ECONNRESET';
+    const err = new Error('fetch failed', { cause });
+    expect(isTransientError(err)).toBe(true);
+  });
+
+  it('returns false for non-transient errors', () => {
+    expect(isTransientError(new Error('something else'))).toBe(false);
+  });
+
+  it('returns false for non-Error values', () => {
+    expect(isTransientError('string error')).toBe(false);
+    expect(isTransientError(null)).toBe(false);
+    expect(isTransientError(42)).toBe(false);
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -65,6 +65,14 @@ describe('isTransientError', () => {
     expect(isTransientError(err)).toBe(true);
   });
 
+  it('returns true for deeply nested transient cause', () => {
+    const root = new Error('read ECONNRESET');
+    (root as NodeJS.ErrnoException).code = 'ECONNRESET';
+    const mid = new Error('socket hang up', { cause: root });
+    const outer = new TypeError('fetch failed', { cause: mid });
+    expect(isTransientError(outer)).toBe(true);
+  });
+
   it('returns false for non-transient errors', () => {
     expect(isTransientError(new Error('something else'))).toBe(false);
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,19 +30,15 @@ const TRANSIENT_CODES = new Set([
  *          AbortError, and timeout-related fetch errors.
  */
 export function isTransientError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
+  let current: unknown = err;
 
-  if (TRANSIENT_CODES.has(err.name)) return true;
+  while (current instanceof Error) {
+    if (TRANSIENT_CODES.has(current.name)) return true;
 
-  const code = (err as NodeJS.ErrnoException).code;
-  if (typeof code === 'string' && TRANSIENT_CODES.has(code)) return true;
+    const code = (current as NodeJS.ErrnoException).code;
+    if (typeof code === 'string' && TRANSIENT_CODES.has(code)) return true;
 
-  const cause = (err as { cause?: unknown }).cause;
-  if (cause instanceof Error) {
-    const causeCode = (cause as NodeJS.ErrnoException).code;
-    if (typeof causeCode === 'string' && TRANSIENT_CODES.has(causeCode))
-      return true;
-    if (TRANSIENT_CODES.has(cause.name)) return true;
+    current = (current as { cause?: unknown }).cause;
   }
 
   return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,3 +13,37 @@
 export function getErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
+
+/** Error codes / names that indicate transient network failures. */
+const TRANSIENT_CODES = new Set([
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'AbortError',
+]);
+
+/**
+ * Classify whether an error is a transient network failure.
+ *
+ * @param err - The caught value.
+ * @returns `true` for ECONNRESET, ETIMEDOUT, UND_ERR_CONNECT_TIMEOUT,
+ *          AbortError, and timeout-related fetch errors.
+ */
+export function isTransientError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+
+  if (TRANSIENT_CODES.has(err.name)) return true;
+
+  const code = (err as NodeJS.ErrnoException).code;
+  if (typeof code === 'string' && TRANSIENT_CODES.has(code)) return true;
+
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause instanceof Error) {
+    const causeCode = (cause as NodeJS.ErrnoException).code;
+    if (typeof causeCode === 'string' && TRANSIENT_CODES.has(causeCode))
+      return true;
+    if (TRANSIENT_CODES.has(cause.name)) return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

Fixes #83 and #77.

### #83: Config apply handler reads from wrong path

**Root cause:** \createConfigApplyHandler\ derived the config file path from \getComponentConfigDir()\, which uses \configRoot\ set during \init()\. When services are started with \--config /explicit/path\, \configRoot\ still defaults to \./config\ (relative to CWD), so the handler reads from a nonexistent file, gets \{}\, merges the patch into nothing, and validation fails.

**Fix:** Added \egisterComponentConfigPath(name, absolutePath)\ and \getComponentConfigPath(name)\ to core init state. \createConfigApplyHandler\ now checks for a registered path first, falling back to the current \getComponentConfigDir()\ derivation if none is registered. Backward-compatible — no consumer changes required until components opt in.

**Consumer integration:** Each component's launcher (e.g. \start-server.ts\) should call \egisterComponentConfigPath('server', resolvedConfigPath)\ after resolving the \--config\ argument. This is a follow-up task per component.

### #77: Transient fetch error log hygiene

**Problem:** Plugin refresh helpers logged full stack traces for recoverable network failures (ECONNRESET, timeouts, AbortError) during background content cache refreshes.

**Fix:** Added \isTransientFetchError()\ classifier in \utils.ts\. \createAsyncContentCache\ now emits concise single-line warnings for transient failures and preserves full stack traces for unexpected errors.

## Changes

| File | Change |
|------|--------|
| \src/init.ts\ | Added \egisterComponentConfigPath()\, \getComponentConfigPath()\ |
| \src/init.test.ts\ | Tests for path registration and retrieval |
| \src/api/configApplyHandler.ts\ | Use registered path with fallback |
| \src/api/configApplyHandler.test.ts\ | Test registered path override |
| \src/utils.ts\ | Added \isTransientFetchError()\ classifier |
| \src/utils.test.ts\ | Tests for transient error classification |
| \src/component/createAsyncContentCache.ts\ | Concise transient error logging |
| \src/component/createAsyncContentCache.test.ts\ | Tests for log behavior |
| \src/index.ts\ | Export new functions |

## Quality

- ✅ Lint (zero warnings)
- ✅ Typecheck
- ✅ 428/428 tests pass
