### PR TITLE
fix: v0.5.12 bugfixes (#103, #104)

### DIFF
--- a/src/api/configApplyHandler.test.ts
+++ b/src/api/configApplyHandler.test.ts
@@ -225,6 +225,28 @@ describe('createConfigApplyHandler', () => {
     expect(body.warning).toContain('reload failed');
   });
 
+  it('should use explicit configPath when provided', async () => {
+    const altDir = join(testDir, 'explicit-config');
+    mkdirSync(altDir, { recursive: true });
+    const explicitPath = join(altDir, 'config.json');
+    writeFileSync(
+      explicitPath,
+      JSON.stringify({ port: 7777, watchPaths: ['/explicit'], debug: false }),
+    );
+
+    const handler = createConfigApplyHandler(makeDescriptor(), explicitPath);
+    const result = await handler({ patch: { port: 3000 } });
+
+    expect(result.status).toBe(200);
+
+    const written = JSON.parse(readFileSync(explicitPath, 'utf-8')) as Record<
+      string,
+      unknown
+    >;
+    expect(written.port).toBe(3000);
+    expect(written.watchPaths).toEqual(['/explicit']);
+  });
+
   it('should use registered config path instead of derived path', async () => {
     // Create an alternate config directory outside the default configRoot
     const altDir = join(testDir, 'alt-config');

--- a/src/api/configApplyHandler.ts
+++ b/src/api/configApplyHandler.ts
@@ -104,21 +104,25 @@ function readConfigFile(filePath: string): Record<string, unknown> {
  * 5. Calls `descriptor.onConfigApply` with the merged config (if defined)
  *
  * @param descriptor - The component descriptor.
+ * @param configPath - Optional explicit config file path. When provided, takes
+ *   precedence over registered and derived paths.
  * @returns An async handler returning `{ status, body }`.
  */
 export function createConfigApplyHandler(
   descriptor: JeevesComponentDescriptor,
+  configPath?: string,
 ): ConfigApplyHandler {
   return async (request: ConfigApplyRequest): Promise<ConfigApplyResult> => {
     const { patch, replace } = request;
 
-    // Use registered config path if available, otherwise derive from configRoot
-    const configPath =
+    // Prefer explicit > registered > derived config path
+    const resolvedConfigPath =
+      configPath ??
       getComponentConfigPath(descriptor.name) ??
       join(getComponentConfigDir(descriptor.name), descriptor.configFileName);
 
     // Read existing config
-    const existing = readConfigFile(configPath);
+    const existing = readConfigFile(resolvedConfigPath);
 
     // Merge or replace
     const mergeFn = descriptor.customMerge ?? deepMerge;
@@ -144,7 +148,7 @@ export function createConfigApplyHandler(
     // Write atomically
     try {
       const json = JSON.stringify(validatedConfig, null, 2) + '\n';
-      atomicWrite(configPath, json);
+      atomicWrite(resolvedConfigPath, json);
     } catch (err: unknown) {
       return {
         status: 500,

--- a/src/cli/plugin/createPluginCli.test.ts
+++ b/src/cli/plugin/createPluginCli.test.ts
@@ -180,6 +180,19 @@ describe('createPluginCli', () => {
     expect(entries['jeeves-watcher-openclaw']).toBeUndefined();
   });
 
+  it('install should run npm install in extension directory', async () => {
+    const program = createPluginCli({
+      pluginId: 'jeeves-watcher-openclaw',
+      importMetaUrl,
+      pluginPackage: '@karmaniverous/jeeves-watcher-openclaw',
+    });
+
+    await program.parseAsync(['node', 'test', 'install']);
+
+    const extDir = join(openClawHome, 'extensions', 'jeeves-watcher-openclaw');
+    expect(existsSync(join(extDir, 'package-lock.json'))).toBe(true);
+  });
+
   it('install should copy package.json and openclaw.plugin.json to extensions', async () => {
     const program = createPluginCli({
       pluginId: 'jeeves-watcher-openclaw',

--- a/src/cli/plugin/createPluginCli.ts
+++ b/src/cli/plugin/createPluginCli.ts
@@ -4,6 +4,7 @@
  * @module
  */
 
+import { execSync } from 'node:child_process';
 import {
   copyFileSync,
   existsSync,
@@ -96,11 +97,9 @@ export function createPluginCli(options: CreatePluginCliOptions): Command {
 
       // 1. Copy dist to extensions
       const extensionsDir = join(openClawHome, 'extensions', pluginId);
-      if (!existsSync(distDir)) {
-        throw new Error(
-          `Plugin dist directory not found: ${distDir}. Ensure the plugin is built before installing.`,
-        );
-      }
+      if (!existsSync(distDir))
+        throw new Error(`Plugin dist directory not found: ${distDir}`);
+
       console.log(`Copying dist to ${extensionsDir}...`);
       copyDistFiles(distDir, join(extensionsDir, 'dist'));
 
@@ -112,6 +111,20 @@ export function createPluginCli(options: CreatePluginCliOptions): Command {
         }
       }
       console.log('  ✓ Dist files copied');
+
+      // 1b. Install production dependencies
+      console.log('Installing dependencies...');
+      try {
+        execSync('npm install --omit=dev', {
+          cwd: extensionsDir,
+          stdio: 'pipe',
+        });
+      } catch (err) {
+        throw new Error(`npm install failed in ${extensionsDir}`, {
+          cause: err,
+        });
+      }
+      console.log('  ✓ Dependencies installed');
 
       // 2. Patch openclaw.json
       console.log('Patching OpenClaw config...');
@@ -160,12 +173,9 @@ export function createPluginCli(options: CreatePluginCliOptions): Command {
       // 4. Write initial HEARTBEAT entry and seed jeeves skill
       try {
         const cfgRoot = opts.configRoot;
-        const agents = config.agents as Record<string, unknown> | undefined;
-        const defaults = agents?.defaults as
-          | Record<string, unknown>
-          | undefined;
-        const ws =
-          opts.workspace ?? (defaults?.workspace as string | undefined);
+        const ag = config.agents as Record<string, unknown> | undefined;
+        const defs = ag?.defaults as Record<string, unknown> | undefined;
+        const ws = opts.workspace ?? (defs?.workspace as string | undefined);
 
         if (ws) {
           init({ workspacePath: ws, configRoot: cfgRoot });
@@ -201,7 +211,6 @@ export function createPluginCli(options: CreatePluginCliOptions): Command {
       } catch {
         // HEARTBEAT + skill seeding are best-effort during install
       }
-
       // 5. Write component version
       try {
         init({
@@ -225,7 +234,6 @@ export function createPluginCli(options: CreatePluginCliOptions): Command {
       console.log();
       console.log(`✅ ${pluginPackage} installed.`);
     });
-
   program
     .command('uninstall')
     .description(`Uninstall the ${componentName} plugin`)
@@ -287,6 +295,5 @@ export function createPluginCli(options: CreatePluginCliOptions): Command {
       console.log();
       console.log(`✅ ${pluginPackage} uninstalled.`);
     });
-
   return program;
 }


### PR DESCRIPTION
## Bugfix release v0.5.12

### fix(plugin): run npm install in extension directory (#103)

The plugin installer CLI copies \dist/\, \package.json\, and \openclaw.plugin.json\ to the extension directory but never ran \
pm install\. Without \
ode_modules/\, the gateway fails to load any plugin that declares dependencies.

Adds \
pm install --omit=dev\ after copying manifests. Throws on failure (this is not best-effort — plugins cannot function without their dependencies).

### fix(api): accept explicit configPath in createConfigApplyHandler (#104)

\createConfigApplyHandler\ derived the config path via \getComponentConfigPath() ?? join(getComponentConfigDir(), configFileName)\. When a component was started with a custom \--config\ path and never called \egisterComponentConfigPath()\, the handler fell back to a derived path that didn't exist — merging the patch into \{}\ and failing Zod validation.

Adds an optional \configPath\ second parameter. Resolution order: explicit > registered > derived.

Closes #103
Closes #104